### PR TITLE
fix(SA3 stuff): utils::data() was not working w/o supplying package =

### DIFF
--- a/R/StrataAreas.fn.R
+++ b/R/StrataAreas.fn.R
@@ -31,8 +31,8 @@
 #' be located in a certain order within the data frame, but it is not necessary.
 #' @param df The stored data frame or a personally created data frame that
 #' is used to calculate areas for the West Coast stratifications. The default
-#' data frame can be accessed using \code{utils::data("SA3")}.
-#' @param convertFactor Multiplier on the areas in SA3, which are in hectares.
+#' data frame can be accessed using \code{utils::data("SA3_v2021.1")}.
+#' @param convertFactor Multiplier on the areas in SA3_v2021.1, which are in hectares.
 #' Default = 0.01 to convert hectares to square km.
 #' @return Returns the \code{strat.df} with entries in the area column containing
 #' the area (square km) for each strata.
@@ -44,7 +44,7 @@
 
 StrataAreas.fn <- function(
   strat.df,
-  df = get(utils::data("SA3_v2021.1", overwrite = TRUE)),
+  df = get(utils::data("SA3_v2021.1", overwrite = TRUE, package = "nwfscSurvey")),
   convertFactor = 0.01
 ) {
 

--- a/R/createStrataDF.fn.R
+++ b/R/createStrataDF.fn.R
@@ -42,8 +42,9 @@
 
 CreateStrataDF.fn <- function(names = NA, depths.shallow, depths.deep, lats.south, lats.north) {
 
-  SA3 <- NULL
-  utils::data("SA3_v2021.1", envir = environment(), overwrite = TRUE)
+  SA3_v2021.1 <- NULL
+  utils::data("SA3_v2021.1", envir = environment(),
+    overwrite = TRUE, package = "nwfscSurvey")
 
   out <- data.frame(
     name = NA,

--- a/man/StrataAreas.fn.Rd
+++ b/man/StrataAreas.fn.Rd
@@ -6,7 +6,7 @@
 \usage{
 StrataAreas.fn(
   strat.df,
-  df = get(utils::data("SA3_v2021.1", overwrite = TRUE)),
+  df = get(utils::data("SA3_v2021.1", overwrite = TRUE, package = "nwfscSurvey")),
   convertFactor = 0.01
 )
 }
@@ -22,9 +22,9 @@ be located in a certain order within the data frame, but it is not necessary.}
 
 \item{df}{The stored data frame or a personally created data frame that
 is used to calculate areas for the West Coast stratifications. The default
-data frame can be accessed using \code{utils::data("SA3")}.}
+data frame can be accessed using \code{utils::data("SA3_v2021.1")}.}
 
-\item{convertFactor}{Multiplier on the areas in SA3, which are in hectares.
+\item{convertFactor}{Multiplier on the areas in SA3_v2021.1, which are in hectares.
 Default = 0.01 to convert hectares to square km.}
 }
 \value{


### PR DESCRIPTION
happened when I didn't use library(nwfscSurvey) and VASTWestCoast, without
the package loaded it didn't know where to look for the SA3 data base.
Now, by explicitly using package = nwfscSurvey it doesn't matter if you
load the package or just have it installed.

Updated the documentation for SA3_v2021.1 in StrataAreas.fn to use the
new data frame rather than SA3.

Pull request to run tests before merging.