### PR TITLE
Improve example code

### DIFF
--- a/R/plot_proportion.R
+++ b/R/plot_proportion.R
@@ -46,53 +46,56 @@
 #' @examples
 #' \dontrun{
 #' # Add presence/absence factor to data
-#' # temp <- catch_nwfsc_combo |>
-#' #   dplyr::mutate(new = factor(
-#' #    cpue_kg_km2 <= 0,
-#' #     levels = c(FALSE, TRUE),
-#' #     labels = c("Present", "Absent")
-#' #   ))
+#' catch_data <- pull_catch(
+#'   common_name = "petrale sole"
+#' )
+#' temp <- catch_data |>
+#'   dplyr::mutate(new = factor(
+#'     cpue_kg_km2 <= 0,
+#'     levels = c(FALSE, TRUE),
+#'     labels = c("Present", "Absent")
+#'   ))
 #'
 #' # Plot depth bins (50 m) by presence/absence with default colors
-#' # plot_proportion(
-#' #  data = temp,
-#' #  column_factor = new,
-#' #  column_bin = Depth_m,
-#' #  width = 50,
-#' #  boundary = 0
-#' # )
-#' # Plot latitude bins (1 decimal degree) by presence/absence with custom
-#' # colors
-#' # plot_proportion(
-#' #  data = temp,
-#' #  column_factor = new,
-#' #  column_bin = Latitude_dd,
-#' #  width = 1,
-#' #  boundary = 0
-#' # ) +
-#' #  ggplot2::scale_fill_manual(values = c(
-#' #    "darkorchid3",
-#' #    grDevices::gray(0.7)
-#' #  ))
+#' plot_proportion(
+#'   data = temp,
+#'   column_factor = new,
+#'   column_bin = Depth_m,
+#'   width = 50,
+#'   boundary = 0
+#' )
+#' # Plot latitude bins (1 decimal degree) by presence/absence
+#' # with custom colors
+#' plot_proportion(
+#'   data = temp,
+#'   column_factor = new,
+#'   column_bin = Latitude_dd,
+#'   width = 1,
+#'   boundary = 0
+#' ) +
+#'   ggplot2::scale_fill_manual(values = c(
+#'     "darkorchid3",
+#'     grDevices::gray(0.7)
+#'   ))
 #' # Plot depth bins (25 m) by sex (F, M, U)
-#' # plot_proportion(
-#' #  data = bio_nwfsc_combo |>
-#' #    dplyr::mutate(Sex = codify_sex(Sex)),
-#' #  column_factor = Sex,
-#' #  column_bin = Depth_m,
-#' #  width = 25,
-#' #  boundary = 0
-#' # )
+#' plot_proportion(
+#'   data = bio_nwfsc_combo |>
+#'     dplyr::mutate(Sex = codify_sex(Sex)),
+#'   column_factor = Sex,
+#'   column_bin = Depth_m,
+#'   width = 25,
+#'   boundary = 0
+#' )
 #' # Change to equal sized bars
-#' # plot_proportion(
-#' #  data = bio_nwfsc_combo |>
-#' #    dplyr::mutate(Sex = codify_sex(Sex)),
-#' #  column_factor = Sex,
-#' #  column_bin = Depth_m,
-#' #  width = 25,
-#' #  boundary = 0,
-#' #  bar_width = "equal"
-#' # )
+#' plot_proportion(
+#'   data = bio_nwfsc_combo |>
+#'     dplyr::mutate(Sex = codify_sex(Sex)),
+#'   column_factor = Sex,
+#'   column_bin = Depth_m,
+#'   width = 25,
+#'   boundary = 0,
+#'   bar_width = "equal"
+#' )
 #' }
 plot_proportion <- function(
   data,
@@ -192,7 +195,7 @@ plot_proportion <- function(
 #' @family warehouse
 #' @examples
 #' \dontrun{
-#' # test <- wh_plot_proportion(catch_nwfsc_combo, bio_nwfsc_combo)
+#' test <- wh_plot_proportion(catch_nwfsc_combo, bio_nwfsc_combo)
 #' }
 wh_plot_proportion <- function(
   data_catch,

--- a/R/pull_catch.R
+++ b/R/pull_catch.R
@@ -87,8 +87,8 @@
 #'
 #' @examples
 #' \dontrun{
-#' # survey is only arg that has to be specified
-#' catch_data <- pull_catch(survey = "NWFSC.Combo")
+#' # Pull catch for all species
+#' catch_data <- pull_catch()
 #'
 #' # Example with specified common name
 #' catch_data <- pull_catch(

--- a/man/plot_proportion.Rd
+++ b/man/plot_proportion.Rd
@@ -62,53 +62,56 @@ data that can be modified upon return.
 \examples{
 \dontrun{
 # Add presence/absence factor to data
-# temp <- catch_nwfsc_combo |>
-#   dplyr::mutate(new = factor(
-#    cpue_kg_km2 <= 0,
-#     levels = c(FALSE, TRUE),
-#     labels = c("Present", "Absent")
-#   ))
+catch_data <- pull_catch(
+  common_name = "petrale sole"
+)
+temp <- catch_data |>
+  dplyr::mutate(new = factor(
+    cpue_kg_km2 <= 0,
+    levels = c(FALSE, TRUE),
+    labels = c("Present", "Absent")
+  ))
 
 # Plot depth bins (50 m) by presence/absence with default colors
-# plot_proportion(
-#  data = temp,
-#  column_factor = new,
-#  column_bin = Depth_m,
-#  width = 50,
-#  boundary = 0
-# )
-# Plot latitude bins (1 decimal degree) by presence/absence with custom
-# colors
-# plot_proportion(
-#  data = temp,
-#  column_factor = new,
-#  column_bin = Latitude_dd,
-#  width = 1,
-#  boundary = 0
-# ) +
-#  ggplot2::scale_fill_manual(values = c(
-#    "darkorchid3",
-#    grDevices::gray(0.7)
-#  ))
+plot_proportion(
+  data = temp,
+  column_factor = new,
+  column_bin = Depth_m,
+  width = 50,
+  boundary = 0
+)
+# Plot latitude bins (1 decimal degree) by presence/absence
+# with custom colors
+plot_proportion(
+  data = temp,
+  column_factor = new,
+  column_bin = Latitude_dd,
+  width = 1,
+  boundary = 0
+) +
+  ggplot2::scale_fill_manual(values = c(
+    "darkorchid3",
+    grDevices::gray(0.7)
+  ))
 # Plot depth bins (25 m) by sex (F, M, U)
-# plot_proportion(
-#  data = bio_nwfsc_combo |>
-#    dplyr::mutate(Sex = codify_sex(Sex)),
-#  column_factor = Sex,
-#  column_bin = Depth_m,
-#  width = 25,
-#  boundary = 0
-# )
+plot_proportion(
+  data = bio_nwfsc_combo |>
+    dplyr::mutate(Sex = codify_sex(Sex)),
+  column_factor = Sex,
+  column_bin = Depth_m,
+  width = 25,
+  boundary = 0
+)
 # Change to equal sized bars
-# plot_proportion(
-#  data = bio_nwfsc_combo |>
-#    dplyr::mutate(Sex = codify_sex(Sex)),
-#  column_factor = Sex,
-#  column_bin = Depth_m,
-#  width = 25,
-#  boundary = 0,
-#  bar_width = "equal"
-# )
+plot_proportion(
+  data = bio_nwfsc_combo |>
+    dplyr::mutate(Sex = codify_sex(Sex)),
+  column_factor = Sex,
+  column_bin = Depth_m,
+  width = 25,
+  boundary = 0,
+  bar_width = "equal"
+)
 }
 }
 \seealso{

--- a/man/pull_catch.Rd
+++ b/man/pull_catch.Rd
@@ -106,8 +106,8 @@ in an index-standardization procedure.
 }
 \examples{
 \dontrun{
-# survey is only arg that has to be specified
-catch_data <- pull_catch(survey = "NWFSC.Combo")
+# Pull catch for all species
+catch_data <- pull_catch()
 
 # Example with specified common name
 catch_data <- pull_catch(

--- a/man/wh_plot_proportion.Rd
+++ b/man/wh_plot_proportion.Rd
@@ -40,7 +40,7 @@ standard column names of data pulled from the warehouse.
 }
 \examples{
 \dontrun{
-# test <- wh_plot_proportion(catch_nwfsc_combo, bio_nwfsc_combo)
+test <- wh_plot_proportion(catch_nwfsc_combo, bio_nwfsc_combo)
 }
 }
 \seealso{


### PR DESCRIPTION
Here are some pretty trivial changes.

The example code for `plot_prortion()` at https://pfmc-assessments.github.io/nwfscSurvey/reference/plot_proportion.html can't be easily copied and pasted because of unnecessary `#` marks in the code. I check all the other files and this is the only one with the extra comments.

This PR removes the `#` as well as adding use of `pull_catch()` in order to make it even easier to run the examples.
While looking at the example for `pull_catch()`, I also saw an obsolete comment about survey needing to be specified.