### PR TITLE
clean up roxygen comments for deprecated functions

### DIFF
--- a/R/Format.AKSlope.fn.R
+++ b/R/Format.AKSlope.fn.R
@@ -1,12 +1,7 @@
-#' Rename AFSC slope survey columns from data pulled before 2017
+#' Deprecated function replaced by pull_catch() and pull_bio()
 #'
 #' @details
-#' Rename columns in the AFSC slope survey data file
-#' received prior to the creation of the NWFSC data
-#' warehouse. This function converts the older data files
-#' to create the needed column names to work within survey
-#' package functions. Output from this function will be list
-#' of containing catch, length, and age data.
+#' This function is no longer used.  Please use pull_catch() and pull_bio() to get properly formatted and filtered data.
 #'
 #' @inheritParams pull_catch
 #' @param datTows A data frame of catch data for the
@@ -21,22 +16,6 @@
 #'
 #' @author Chantel Wetzel
 #' @export
-#' @family helper function
-#'
-#' @examples
-#' \dontrun{
-#' # load data files for catch and biological data
-#' load("Tri.Shelf.and.AFSC.Slope.canary.Catch.24.May.11.dmp")
-#' catch <- Tri.Shelf.and.AFSC.Slope.canary.Catch.24.May.11
-#' load("AFSC.Slope.Shelf.sable.bio.5.24.11.dmp")
-#' bio <- AK.Surveys.Bio.sablefish.24.May.11
-#' # call function and reformat the data
-#' filter.dat <- Format.AKSlope.fn(
-#'   datTows = catch,
-#'   datL = bio,
-#'   start.year = 1997
-#' )
-#' }
 #'
 Format.AKSlope.fn <- function(
   dir = NULL,

--- a/R/ReadInAges.fn.R
+++ b/R/ReadInAges.fn.R
@@ -1,14 +1,4 @@
-#' Cleans triennial survey data by year and area
-#'
-#' @details
-#' Reads in the West Coast Triennial survey data and filters the data into what
-#' is necessary. It reads in data and makes sure only the species necessary are
-#' kept may want to keep NA (blank in Excel) to select the zero tows
-#' removeCAN is a flag if you want tows in Canadian waters removed.
-#'
-#' Necessary column names
-#'    SPECIES_CODE
-#'    AGE
+#' Deprecated function replaced by pull_bio()
 #'
 #' @inheritParams pull_catch
 #' @param dat data file name

--- a/R/ReadInLengths.R
+++ b/R/ReadInLengths.R
@@ -1,12 +1,5 @@
-#' Reads in the compositional survey data and filters the data into what is necessary
-#' It reads in catch and station data and makes sure only the species necessary are kept
-#' ### may want to keep NA (blank in Excel) to select the zero tows
-#' removeCAN is a flag if you want tows in Canadian waters removed
-#'    need the file called foreign_hauls.csv
+#' Deprecated function replaced by pull_bio()
 #'
-#' Necessary column names
-#'    SPECIES_CODE
-#'    LENGTH
 #' @inheritParams pull_catch
 #' @param dat data file name
 #'

--- a/man/Format.AKSlope.fn.Rd
+++ b/man/Format.AKSlope.fn.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Format.AKSlope.fn.R
 \name{Format.AKSlope.fn}
 \alias{Format.AKSlope.fn}
-\title{Rename AFSC slope survey columns from data pulled before 2017}
+\title{Deprecated function replaced by pull_catch() and pull_bio()}
 \usage{
 Format.AKSlope.fn(
   dir = NULL,
@@ -32,41 +32,11 @@ survey is 1997.}
 warnings to the console. The default is \code{TRUE}.}
 }
 \description{
-Rename AFSC slope survey columns from data pulled before 2017
+Deprecated function replaced by pull_catch() and pull_bio()
 }
 \details{
-Rename columns in the AFSC slope survey data file
-received prior to the creation of the NWFSC data
-warehouse. This function converts the older data files
-to create the needed column names to work within survey
-package functions. Output from this function will be list
-of containing catch, length, and age data.
-}
-\examples{
-\dontrun{
-# load data files for catch and biological data
-load("Tri.Shelf.and.AFSC.Slope.canary.Catch.24.May.11.dmp")
-catch <- Tri.Shelf.and.AFSC.Slope.canary.Catch.24.May.11
-load("AFSC.Slope.Shelf.sable.bio.5.24.11.dmp")
-bio <- AK.Surveys.Bio.sablefish.24.May.11
-# call function and reformat the data
-filter.dat <- Format.AKSlope.fn(
-  datTows = catch,
-  datL = bio,
-  start.year = 1997
-)
-}
-
-}
-\seealso{
-Other helper function:
-\code{\link[=check_dir]{check_dir()}},
-\code{\link[=check_survey]{check_survey()}},
-\code{\link[=combine_tows]{combine_tows()}},
-\code{\link[=createMatrix]{createMatrix()}},
-\code{\link[=filter_pull]{filter_pull()}}
+This function is no longer used.  Please use pull_catch() and pull_bio() to get properly formatted and filtered data.
 }
 \author{
 Chantel Wetzel
 }
-\concept{helper function}

--- a/man/ReadInAges.fn.Rd
+++ b/man/ReadInAges.fn.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/ReadInAges.fn.R
 \name{ReadInAges.fn}
 \alias{ReadInAges.fn}
-\title{Cleans triennial survey data by year and area}
+\title{Deprecated function replaced by pull_bio()}
 \usage{
 ReadInAges.fn(dat, subset_years = NULL, verbose = TRUE)
 }
@@ -16,17 +16,7 @@ provide 1977, alternative input would be 1980:2002 to remove only 1977.}
 warnings to the console. The default is \code{TRUE}.}
 }
 \description{
-Cleans triennial survey data by year and area
-}
-\details{
-Reads in the West Coast Triennial survey data and filters the data into what
-is necessary. It reads in data and makes sure only the species necessary are
-kept may want to keep NA (blank in Excel) to select the zero tows
-removeCAN is a flag if you want tows in Canadian waters removed.
-
-Necessary column names
-SPECIES_CODE
-AGE
+Deprecated function replaced by pull_bio()
 }
 \author{
 Allan Hicks and Chantel Wetzel

--- a/man/ReadInLengths.fn.Rd
+++ b/man/ReadInLengths.fn.Rd
@@ -2,13 +2,7 @@
 % Please edit documentation in R/ReadInLengths.R
 \name{ReadInLengths.fn}
 \alias{ReadInLengths.fn}
-\title{Reads in the compositional survey data and filters the data into what is necessary
-It reads in catch and station data and makes sure only the species necessary are kept
-\subsection{may want to keep NA (blank in Excel) to select the zero tows}{
-
-removeCAN is a flag if you want tows in Canadian waters removed
-need the file called foreign_hauls.csv
-}}
+\title{Deprecated function replaced by pull_bio()}
 \usage{
 ReadInLengths.fn(dat, verbose = TRUE)
 }
@@ -19,9 +13,7 @@ ReadInLengths.fn(dat, verbose = TRUE)
 warnings to the console. The default is \code{TRUE}.}
 }
 \description{
-Necessary column names
-SPECIES_CODE
-LENGTH
+Deprecated function replaced by pull_bio()
 }
 \author{
 Allan Hicks and Chantel Wetzel

--- a/man/check_dir.Rd
+++ b/man/check_dir.Rd
@@ -32,7 +32,6 @@ check_dir(getwd())
 }
 \seealso{
 Other helper function:
-\code{\link[=Format.AKSlope.fn]{Format.AKSlope.fn()}},
 \code{\link[=check_survey]{check_survey()}},
 \code{\link[=combine_tows]{combine_tows()}},
 \code{\link[=createMatrix]{createMatrix()}},

--- a/man/check_survey.Rd
+++ b/man/check_survey.Rd
@@ -46,7 +46,6 @@ Check and create survey string
 }
 \seealso{
 Other helper function:
-\code{\link[=Format.AKSlope.fn]{Format.AKSlope.fn()}},
 \code{\link[=check_dir]{check_dir()}},
 \code{\link[=combine_tows]{combine_tows()}},
 \code{\link[=createMatrix]{createMatrix()}},

--- a/man/combine_tows.Rd
+++ b/man/combine_tows.Rd
@@ -32,7 +32,6 @@ This also occurs if cryptic species pairs are all returned
 }
 \seealso{
 Other helper function:
-\code{\link[=Format.AKSlope.fn]{Format.AKSlope.fn()}},
 \code{\link[=check_dir]{check_dir()}},
 \code{\link[=check_survey]{check_survey()}},
 \code{\link[=createMatrix]{createMatrix()}},

--- a/man/createMatrix.Rd
+++ b/man/createMatrix.Rd
@@ -11,7 +11,6 @@ Survey name matching function used when pull from the data warehouse
 }
 \seealso{
 Other helper function:
-\code{\link[=Format.AKSlope.fn]{Format.AKSlope.fn()}},
 \code{\link[=check_dir]{check_dir()}},
 \code{\link[=check_survey]{check_survey()}},
 \code{\link[=combine_tows]{combine_tows()}},

--- a/man/filter_pull.Rd
+++ b/man/filter_pull.Rd
@@ -36,7 +36,6 @@ was not selected in the original data pull.
 }
 \seealso{
 Other helper function:
-\code{\link[=Format.AKSlope.fn]{Format.AKSlope.fn()}},
 \code{\link[=check_dir]{check_dir()}},
 \code{\link[=check_survey]{check_survey()}},
 \code{\link[=combine_tows]{combine_tows()}},


### PR DESCRIPTION
While showing off https://pfmc-assessments.github.io/nwfscSurvey/ as a shining example of a great pkgdown site, I came across some bad formatting due to lack of separation between function title and description in the roxygen code:
<img width="1085" height="324" alt="image" src="https://github.com/user-attachments/assets/b001c754-b4fa-4502-b34a-330a47a15d90" />

Given that `ReadInLengths.fn()` was already deprecated, I went ahead and simplified the documentation of all three functions that called `lifecycle::deprecate_stop()`.
